### PR TITLE
feat: add template parameters

### DIFF
--- a/examples/account-default-template.yaml
+++ b/examples/account-default-template.yaml
@@ -8,6 +8,10 @@ spec:
     templateInstances:
     - spec:
         template: space-restrictions
+        # You can also use parameters here
+        # parameters:
+        # - name: DEFAULT_CPU_REQUESTS
+        #   value: "1"
   subjects:
   - kind: User
     name: john

--- a/examples/template-helm.yaml
+++ b/examples/template-helm.yaml
@@ -11,3 +11,5 @@ resources:
         repoUrl: https://charts.bitnami.com/bitnami
     values: |
       redisPort: 6379
+      # Use a predefined parameter here
+      myOtherValue: ${NAMESPACE}

--- a/examples/template-instance-sync.yaml
+++ b/examples/template-instance-sync.yaml
@@ -1,7 +1,10 @@
 apiVersion: config.kiosk.sh/v1alpha1
 kind: TemplateInstance
 metadata:
-  name: redis-instance-sync
+  name: space-restrictions-instance-sync
 spec:
-  template: redis
+  template: space-restrictions
   sync: true
+  parameters:
+  - name: DEFAULT_CPU_REQUESTS
+    value: "1"

--- a/examples/template-manifests.yaml
+++ b/examples/template-manifests.yaml
@@ -2,26 +2,34 @@ apiVersion: config.kiosk.sh/v1alpha1
 kind: Template
 metadata:
   name: space-restrictions
+# This section defines parameters that can be used for this template
+# Can be used in resources.manifests and resources.helm.values
+parameters:
+  # Name of the parameter
+  - name: DEFAULT_CPU_LIMIT
+    # The default value of the parameter
+    value: "1"
+  - name: DEFAULT_CPU_REQUESTS
+    value: "0.5"
+    # If a parameter is required the template instance will need to set it
+    # required: true
+    # Make sure only values are entered for this parameter
+    validation: "^[0-9]*\\.?[0-9]+$"
 resources:
   manifests:
-  - kind: NetworkPolicy
-    apiVersion: networking.k8s.io/v1
-    metadata:
-      name: deny-cross-ns-traffic
-    spec:
-      podSelector:
-        matchLabels:
-      ingress:
-      - from:
-        - podSelector: {}
-  - apiVersion: v1
-    kind: LimitRange
-    metadata:
-      name: space-limit-range
-    spec:
-      limits:
-      - default:
-          cpu: 1
-        defaultRequest:
-          cpu: 0.5
-        type: Container
+    - apiVersion: v1
+      kind: LimitRange
+      metadata:
+        name: space-limit-range
+        annotations:
+          # Parameters can also be used inside a string
+          example-parameter: "Hello from ${NAMESPACE} - ${WILL_NOT_BE_REPLACED}"
+      spec:
+        limits:
+          - default:
+              # Use the DEFAULT_CPU_LIMIT parameter here and
+              # parse it as json, which renders the "1" as 1. 
+              cpu: "${{DEFAULT_CPU_LIMIT}}"
+            defaultRequest:
+              cpu: "${{DEFAULT_CPU_REQUESTS}}"
+            type: Container

--- a/pkg/apis/config/v1alpha1/account_types.go
+++ b/pkg/apis/config/v1alpha1/account_types.go
@@ -65,7 +65,7 @@ type AccountSpaceTemplate struct {
 
 // AccountTemplateInstanceTemplate defines a template instance template
 type AccountTemplateInstanceTemplate struct {
-	// The metadata of the template instace to create
+	// The metadata of the template instance to create
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/pkg/apis/config/v1alpha1/template_types.go
+++ b/pkg/apis/config/v1alpha1/template_types.go
@@ -32,6 +32,25 @@ type TemplateResources struct {
 	Helm *HelmConfiguration `json:"helm,omitempty"`
 }
 
+type TemplateParameter struct {
+	// Name is the name of the parameter
+	Name string `json:"name,omitempty"`
+
+	// Value is the default value of the parameter
+	// +optional
+	Value string `json:"value,omitempty"`
+
+	// If required is true, the template instance must
+	// define this parameter, otherwise the deployment will fail.
+	// +optional
+	Required bool `json:"required,omitempty"`
+
+	// Validation takes a regular expression as value to
+	// verify the provided value does match expected values.
+	// +optional
+	Validation string `json:"validation,omitempty"`
+}
+
 // EmbeddedResource holds a kubernetes resource
 // +kubebuilder:validation:XPreserveUnknownFields
 // +kubebuilder:validation:XEmbeddedResource
@@ -119,6 +138,14 @@ type Template struct {
 
 	// +optional
 	Resources TemplateResources `json:"resources,omitempty"`
+
+	// Parameters can be used to replace certain parts of the template. A parameter is referenced
+	// by this format: ${NAME}, to parse the value as an expression write ${{NAME}} instead. Besides the
+	// parameters defined here, the following predefined parameters can be used:
+	// - ${NAMESPACE}: the namespace where the template instance was created
+	// - ${ACCOUNT}: the account name of the account that owns the space (if any)
+	// +optional
+	Parameters []TemplateParameter `json:"parameters,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/config/v1alpha1/templateinstance_types.go
+++ b/pkg/apis/config/v1alpha1/templateinstance_types.go
@@ -27,9 +27,22 @@ const TemplateInstanceNoOwnerAnnotation = "templateinstance.config.kiosk.sh/no-o
 type TemplateInstanceSpec struct {
 	// The template to instantiate. This is an immutable field
 	Template string `json:"template"`
+
 	// If true the template instance will keep the deployed resources in sync with the template.
 	// +optional
 	Sync bool `json:"sync,omitempty"`
+
+	// Parameters hold the values of the defined parameters in the template
+	// +optional
+	Parameters []TemplateInstanceParameter `json:"parameters,omitempty"`
+}
+
+type TemplateInstanceParameter struct {
+	// Name is the name of the parameter to set
+	Name string `json:"name,omitempty"`
+
+	// Value is the value of the parameter to set
+	Value string `json:"value,omitempty"`
 }
 
 // TemplateInstanceStatus describes the current status of the template instance in the cluster

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -54,9 +54,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.Template":                        schema_pkg_apis_config_v1alpha1_Template(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstance":                schema_pkg_apis_config_v1alpha1_TemplateInstance(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceList":            schema_pkg_apis_config_v1alpha1_TemplateInstanceList(ref),
+		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceParameter":       schema_pkg_apis_config_v1alpha1_TemplateInstanceParameter(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceSpec":            schema_pkg_apis_config_v1alpha1_TemplateInstanceSpec(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceStatus":          schema_pkg_apis_config_v1alpha1_TemplateInstanceStatus(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateList":                    schema_pkg_apis_config_v1alpha1_TemplateList(ref),
+		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateParameter":               schema_pkg_apis_config_v1alpha1_TemplateParameter(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateResources":               schema_pkg_apis_config_v1alpha1_TemplateResources(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/tenancy/v1alpha1.Account":                        schema_pkg_apis_tenancy_v1alpha1_Account(ref),
 		"github.com/loft-sh/kiosk/pkg/apis/tenancy/v1alpha1.AccountList":                    schema_pkg_apis_tenancy_v1alpha1_AccountList(ref),
@@ -1212,7 +1214,7 @@ func schema_pkg_apis_config_v1alpha1_AccountTemplateInstanceTemplate(ref common.
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The metadata of the template instace to create",
+							Description: "The metadata of the template instance to create",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -1457,11 +1459,24 @@ func schema_pkg_apis_config_v1alpha1_Template(ref common.ReferenceCallback) comm
 							Ref: ref("github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateResources"),
 						},
 					},
+					"parameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Parameters can be used to replace certain parts of the template. A parameter is referenced by this format: ${NAME}, to parse the value as an expression write ${{NAME}} instead. Besides the parameters defined here, the following predefined parameters can be used: - ${NAMESPACE}: the namespace where the template instance was created - ${ACCOUNT}: the account name of the account that owns the space (if any)",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateParameter"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateResources", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateParameter", "github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateResources", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -1556,6 +1571,32 @@ func schema_pkg_apis_config_v1alpha1_TemplateInstanceList(ref common.ReferenceCa
 	}
 }
 
+func schema_pkg_apis_config_v1alpha1_TemplateInstanceParameter(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name is the name of the parameter to set",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value is the value of the parameter to set",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func schema_pkg_apis_config_v1alpha1_TemplateInstanceSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -1577,10 +1618,25 @@ func schema_pkg_apis_config_v1alpha1_TemplateInstanceSpec(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"parameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Parameters hold the values of the defined parameters in the template",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceParameter"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"template"},
 			},
 		},
+		Dependencies: []string{
+			"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.TemplateInstanceParameter"},
 	}
 }
 
@@ -1685,6 +1741,46 @@ func schema_pkg_apis_config_v1alpha1_TemplateList(ref common.ReferenceCallback) 
 		},
 		Dependencies: []string{
 			"github.com/loft-sh/kiosk/pkg/apis/config/v1alpha1.Template", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+	}
+}
+
+func schema_pkg_apis_config_v1alpha1_TemplateParameter(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name is the name of the parameter",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value is the default value of the parameter",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"required": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If required is true, the template instance must define this parameter, otherwise the deployment will fail.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"validation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Validation takes a regular expression as value to verify the provided value does match expected values.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/util/parameters/parameters.go
+++ b/pkg/util/parameters/parameters.go
@@ -1,0 +1,70 @@
+package parameters
+
+import (
+	"github.com/ghodss/yaml"
+	"regexp"
+)
+
+// VarMatchRegex is the regex to check if a value matches the kiosk var format
+var VarMatchRegex = regexp.MustCompile("(\\$+?\\{[^\\}]+\\})")
+
+// ExpressionVarMatchRegex is the regex to check if a value matches the kiosk var format
+var ExpressionVarMatchRegex = regexp.MustCompile("^\\$\\{\\{[^\\}]+\\}\\}$")
+
+// ReplaceVarFn defines the replace function
+type ReplaceVarFn func(value string) (string, error)
+
+// ParseString parses a given string, calls replace var on found variables and returns the replaced string
+func ParseString(value string, replace ReplaceVarFn) (interface{}, error) {
+	// check if expression string
+	if ExpressionVarMatchRegex.MatchString(value) {
+		replacedValue, err := replace(value[3 : len(value)-2])
+		if err != nil {
+			return "", err
+		}
+
+		var obj interface{}
+		err = yaml.Unmarshal([]byte(replacedValue), &obj)
+		if err != nil {
+			return "", err
+		}
+
+		return obj, nil
+	}
+
+	matches := VarMatchRegex.FindAllStringIndex(value, -1)
+
+	// No vars found
+	if len(matches) == 0 {
+		return value, nil
+	}
+
+	newValue := value[:matches[0][0]]
+	for index, match := range matches {
+		var (
+			matchStr    = value[match[0]:match[1]]
+			newMatchStr string
+		)
+
+		if matchStr[0] == '$' && matchStr[1] == '$' {
+			newMatchStr = matchStr[1:]
+		} else {
+			offset := 2
+			replacedValue, err := replace(matchStr[offset : len(matchStr)-1])
+			if err != nil {
+				return "", err
+			}
+
+			newMatchStr = replacedValue
+		}
+
+		newValue += newMatchStr
+		if index+1 >= len(matches) {
+			newValue += value[match[1]:]
+		} else {
+			newValue += value[match[1]:matches[index+1][0]]
+		}
+	}
+
+	return newValue, nil
+}

--- a/pkg/util/parameters/parameters_test.go
+++ b/pkg/util/parameters/parameters_test.go
@@ -1,0 +1,116 @@
+package parameters
+
+import (
+	"errors"
+	"github.com/loft-sh/kiosk/pkg/util/testing/ptr"
+	"reflect"
+	"testing"
+)
+
+type testCase struct {
+	input   string
+	replace ReplaceVarFn
+	output  interface{}
+	err     *string
+}
+
+func TestParse(t *testing.T) {
+	testCases := map[string]*testCase{
+		"Single Replace": &testCase{
+			input:   " test abc ${Test} ",
+			replace: func(value string) (string, error) { return "test", nil },
+			output:  " test abc test ",
+		},
+		"Single Replace 2": &testCase{
+			input:   "${Test}",
+			replace: func(value string) (string, error) { return "${Test}", nil },
+			output:  "${Test}",
+		},
+		"Var Name 2": &testCase{
+			input: " test abc ${Test} ",
+			replace: func(value string) (string, error) {
+				if value != "Test" {
+					return "", errors.New("unexpected var name")
+				}
+				return "test", nil
+			},
+			output: " test abc test ",
+		},
+		"Var Name": &testCase{
+			input: " test abc ${Test} ",
+			replace: func(value string) (string, error) {
+				if value != "Test" {
+					return "", errors.New("unexpected var name")
+				}
+				return "test", nil
+			},
+			output: " test abc test ",
+		},
+		"Single Escape": &testCase{
+			input:   " test abc $${Test} ",
+			replace: func(value string) (string, error) { return "", errors.New("Shouldn't match at all") },
+			output:  " test abc ${Test} ",
+		},
+		"Single Escape 2": &testCase{
+			input:   " test abc $$${Test} ",
+			replace: func(value string) (string, error) { return "", errors.New("Shouldn't match at all") },
+			output:  " test abc $${Test} ",
+		},
+		"Multiple Replace": &testCase{
+			input:   " test ${ABC}${Test} abc $${Test}${Test} ",
+			replace: func(value string) (string, error) { return "test", nil },
+			output:  " test testtest abc ${Test}test ",
+		},
+		"Multiple Replace 2": &testCase{
+			input:   "${Test}${Test}${Test}",
+			replace: func(value string) (string, error) { return value, nil },
+			output:  "TestTestTest",
+		},
+		"Return integer": &testCase{
+			input:   "${integer}",
+			replace: func(value string) (string, error) { return "1", nil },
+			output:  "1",
+		},
+		"Return bool": &testCase{
+			input:   "${bool}",
+			replace: func(value string) (string, error) { return "true", nil },
+			output:  "true",
+		},
+		"Return error": &testCase{
+			input:   "${bool}",
+			replace: func(value string) (string, error) { return "", errors.New("Test Error") },
+			err:     ptr.String("Test Error"),
+		},
+		"No match": &testCase{
+			input:   "Test",
+			replace: func(value string) (string, error) { return "", errors.New("Test Error") },
+			output:  "Test",
+		},
+		"Integer": &testCase{
+			input:   "${{Test}}",
+			replace: func(value string) (string, error) { return "1", nil },
+			output:  float64(1),
+		},
+		"Bool": &testCase{
+			input:   "${{Test}}",
+			replace: func(value string) (string, error) { return "false", nil },
+			output:  false,
+		},
+	}
+
+	// Run test cases
+	for key, value := range testCases {
+		out, err := ParseString(value.input, value.replace)
+		if err != nil {
+			if value.err != nil {
+				if *value.err != err.Error() {
+					t.Fatalf("Test %s failed: unexpected error message: expected %s - got %s", key, *value.err, err.Error())
+				}
+			} else {
+				t.Fatalf("Test %s failed: %v", key, err)
+			}
+		} else if out != value.output {
+			t.Fatalf("Test %s failed: expected %v (%v) - got %v (%v)", key, value.output, reflect.TypeOf(value.output), out, reflect.TypeOf(out))
+		}
+	}
+}

--- a/pkg/util/parameters/walk.go
+++ b/pkg/util/parameters/walk.go
@@ -1,0 +1,74 @@
+package parameters
+
+// ReplaceFn defines the replace function
+type ReplaceFn func(value string) (interface{}, error)
+
+// Walk walks over an interface and replaces keys that match the match function with the replace function
+func Walk(d map[interface{}]interface{}, replace ReplaceFn) error {
+	return doWalk(d, replace)
+}
+
+// WalkStringMap walks over an interface and replaces keys that match the match function with the replace function
+func WalkStringMap(d map[string]interface{}, replace ReplaceFn) error {
+	return doWalk(d, replace)
+}
+
+func doWalk(d interface{}, replace ReplaceFn) error {
+	var err error
+
+	switch t := d.(type) {
+	case []interface{}:
+		for idx, val := range t {
+			value, ok := val.(string)
+			if ok == false {
+				err = doWalk(val, replace)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			t[idx], err = replace(value)
+			if err != nil {
+				return err
+			}
+		}
+	case map[string]interface{}:
+		for key, v := range t {
+			value, ok := v.(string)
+			if ok == false {
+				err = doWalk(v, replace)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			t[key], err = replace(value)
+			if err != nil {
+				return err
+			}
+		}
+	case map[interface{}]interface{}:
+		for k, v := range t {
+			value, ok := v.(string)
+			if ok == false {
+				err = doWalk(v, replace)
+				if err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			t[k], err = replace(value)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,7 +28,7 @@ import (
 func Run(command string, args ...string) error {
 	output, err := exec.Command(command, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("Error in command: %v => %s", err, string(output))
+		return fmt.Errorf("error in command: %v => %s", err, string(output))
 	}
 
 	return nil
@@ -38,7 +38,7 @@ func Run(command string, args ...string) error {
 func Output(command string, args ...string) (string, error) {
 	output, err := exec.Command(command, args...).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("Error in command: %v => %s", err, string(output))
+		return "", fmt.Errorf("error in command: %v => %s", err, string(output))
 	}
 
 	return string(output), nil


### PR DESCRIPTION
New template parameters that can be used in `resources.manifests` or `resources.helm.values` to define placeholders that can be used later in a template instance. These placeholders can be either used within a string (e.g. `myvalue: 'Hello from ${NAMESPACE}'`) or can be rendered directly as a json value (e.g. for numbers in `replicas: '${{REPLICAS}}'`. Furthermore there are 2 predefined parameters `${NAMESPACE}` (holds the namespace that the template instance was deployed in) and `${ACCOUNT}` (holds the name of the account that owns the namespace that the the template instance was deployed in). (#68)

For example:
```yaml
apiVersion: config.kiosk.sh/v1alpha1
kind: Template
metadata:
  name: space-restrictions
# This section defines parameters that can be used for this template
# Can be used in resources.manifests and resources.helm.values
parameters:
    # Name of the parameter
  - name: DEFAULT_CPU_LIMIT
    # The default value of the parameter
    value: "1"
  - name: DEFAULT_CPU_REQUESTS
    value: "0.5"
    # If a parameter is required the template instance will need to set it
    required: true
    # Make sure only values are entered for this parameter
    validation: "^[0-9]*\\.?[0-9]+$" 
resources:
  manifests:
  - apiVersion: v1
    kind: LimitRange
    metadata:
      name: space-limit-range
      annotations:
        # Parameters can also be used inside a string
        example-parameter: "Hello from ${NAMESPACE}" 
    spec:
      limits:
      - default:
          # Use the DEFAULT_CPU_LIMIT parameter here and
          # parse it as json, which renders the "1" as 1. 
          cpu: "${{DEFAULT_CPU_LIMIT}}"
        defaultRequest:
          cpu: "${{DEFAULT_CPU_REQUESTS}}"
        type: Container
```

In the template instance the parameters are then used as:
```yaml
apiVersion: config.kiosk.sh/v1alpha1
kind: TemplateInstance
metadata:
  name: space-restrictions-instance-sync
spec:
  template: space-restrictions
  parameters:
  - name: DEFAULT_CPU_REQUESTS
    value: "1"
```

